### PR TITLE
Support for non input elements

### DIFF
--- a/jquery.simple-color-picker.js
+++ b/jquery.simple-color-picker.js
@@ -11,7 +11,8 @@ $.fn.simpleColorPicker = function(options) {
 				, '#990000', '#b45f06', '#bf9000', '#38761d', '#134f5c', '#0b5394', '#351c75', '#741b47'
 				, '#660000', '#783f04', '#7f6000', '#274e13', '#0c343d', '#073763', '#20124d', '#4C1130'],
         showEffect: '',
-        hideEffect: ''
+        hideEffect: '',
+        onChangeColor: false
     };
 
     var opts = $.extend(defaults, options);
@@ -43,12 +44,17 @@ $.fn.simpleColorPicker = function(options) {
         box.hide();
 
         box.find('li.color-box').click(function() {
-            txt.val(opts.colors[this.id.substr(this.id.indexOf('-') + 1)]);
-            txt.blur();
+            if (!txt.is('input')) {
+              txt.val(opts.colors[this.id.substr(this.id.indexOf('-') + 1)]);
+              txt.blur();
+            }
+            if ($.isFunction(defaults.onChangeColor)) {
+              defaults.onChangeColor.call(txt, opts.colors[this.id.substr(this.id.indexOf('-') + 1)]);
+            }
             hideBox(box);
         });
 
-        $('body').click(function() {
+        $('body').live('click', function() {
             hideBox(box);
         });
 
@@ -56,16 +62,24 @@ $.fn.simpleColorPicker = function(options) {
             event.stopPropagation();
         });
 
+        var positionAndShowBox = function(box) {
+          var pos = txt.offset();
+          var left = pos.left + txt.outerWidth() - box.outerWidth();
+          if (left < pos.left) left = pos.left;
+          box.css({ left: left, top: (pos.top + txt.outerHeight()) });
+          showBox(box);
+        }
+
         txt.click(function(event) {
-            event.stopPropagation();
+          event.stopPropagation();
+          if (!txt.is('input')) {
+            // element is not an input so probably a link or div which requires the color box to be shown
+            positionAndShowBox(box);
+          }
         });
 
         txt.focus(function() {
-            var pos = txt.offset();
-            var left = pos.left + txt.outerWidth() - box.outerWidth();
-            if (left < pos.left) left = pos.left;
-            box.css({ left: left, top: (pos.top + txt.outerHeight()) });
-            showBox(box);
+          positionAndShowBox(box);
         });
 
         function hideBox(box) {


### PR DESCRIPTION
I found that your plugin was fantastic, but I needed to use this plugin on an element that was not an input[type=text].  So I modified your plugin to work on any DOM element and fire an optional event once the color has been changed.
