### PR TITLE
modify break way from clear:both to width limit

### DIFF
--- a/jquery.simple-color-picker.js
+++ b/jquery.simple-color-picker.js
@@ -1,5 +1,5 @@
-﻿
-$.fn.simpleColorPicker = function(options) {
+
+$.fn.simpleColorPicker = function (options) {
     var defaults = {
         colorsPerLine: 8,
         colors: ['#000000', '#444444', '#666666', '#999999', '#cccccc', '#eeeeee', '#f3f3f3', '#ffffff'
@@ -17,69 +17,61 @@ $.fn.simpleColorPicker = function(options) {
 
     var opts = $.extend(defaults, options);
 
-    return this.each(function() {
+    return this.each(function () {
         var txt = $(this);
 
         var colorsMarkup = '';
 
         var prefix = txt.attr('id').replace(/-/g, '') + '_';
 
-        for(var i = 0; i < opts.colors.length; i++){
+        for (var i = 0; i < opts.colors.length; i++) {
             var item = opts.colors[i];
-
-            var breakLine = '';
-            if (i % opts.colorsPerLine == 0)
-                breakLine = 'clear: both; ';
-
-            if (i > 0 && breakLine && $.browser && $.browser.msie && $.browser.version <= 7) {
-                breakLine = '';
-                colorsMarkup += '<li style="float: none; clear: both; overflow: hidden; background-color: #fff; display: block; height: 1px; line-height: 1px; font-size: 1px; margin-bottom: -2px;"></li>';
-            }
-
-            colorsMarkup += '<li id="' + prefix + 'color-' + i + '" class="color-box" style="' + breakLine + 'background-color: ' + item + '" title="' + item + '"></li>';
+            colorsMarkup += '<li id="' + prefix + 'color-' + i + '" class="color-box" style="background-color: ' + item + '" title="' + item + '"></li>';
         }
 
-        var box = $('<div id="' + prefix + 'color-picker" class="color-picker" style="position: absolute; left: 0px; top: 0px;"><ul>' + colorsMarkup + '</ul><div style="clear: both;"></div></div>');
+        var boxWidth = 15 * opts.colorsPerLine + (opts.colorsPerLine + 1); //one color size is 15px(see in css), and add size for border width.
+        var box = $('<div id="' + prefix + 'color-picker" class="color-picker" style="width:'+ boxWidth +'px;position: absolute; left: 0px; top: 0px;"><ul>' + colorsMarkup + '</ul><div style="clear: both;"></div></div>');
+
         $('body').append(box);
         box.hide();
 
-        box.find('li.color-box').click(function() {
+        box.find('li.color-box').click(function () {
             if (!txt.is('input')) {
-              txt.val(opts.colors[this.id.substr(this.id.indexOf('-') + 1)]);
-              txt.blur();
+                txt.val(opts.colors[this.id.substr(this.id.indexOf('-') + 1)]);
+                txt.blur();
             }
             if ($.isFunction(defaults.onChangeColor)) {
-              defaults.onChangeColor.call(txt, opts.colors[this.id.substr(this.id.indexOf('-') + 1)]);
+                defaults.onChangeColor.call(txt, opts.colors[this.id.substr(this.id.indexOf('-') + 1)]);
             }
             hideBox(box);
         });
 
-        $('body').live('click', function() {
+        $('body').live('click', function () {
             hideBox(box);
         });
 
-        box.click(function(event) {
+        box.click(function (event) {
             event.stopPropagation();
         });
 
-        var positionAndShowBox = function(box) {
-          var pos = txt.offset();
-          var left = pos.left + txt.outerWidth() - box.outerWidth();
-          if (left < pos.left) left = pos.left;
-          box.css({ left: left, top: (pos.top + txt.outerHeight()) });
-          showBox(box);
+        var positionAndShowBox = function (box) {
+            var pos = txt.offset();
+            var left = pos.left + txt.outerWidth() - box.outerWidth();
+            if (left < pos.left) left = pos.left;
+            box.css({ left: left, top: (pos.top + txt.outerHeight()) });
+            showBox(box);
         }
 
-        txt.click(function(event) {
-          event.stopPropagation();
-          if (!txt.is('input')) {
-            // element is not an input so probably a link or div which requires the color box to be shown
-            positionAndShowBox(box);
-          }
+        txt.click(function (event) {
+            event.stopPropagation();
+            if (!txt.is('input')) {
+                // element is not an input so probably a link or div which requires the color box to be shown
+                positionAndShowBox(box);
+            }
         });
 
-        txt.focus(function() {
-          positionAndShowBox(box);
+        txt.focus(function () {
+            positionAndShowBox(box);
         });
 
         function hideBox(box) {


### PR DESCRIPTION
When I used in IE6 , clear:both make some space line in color picker.
so I changed break line way from using clear:both to using width limit . 

If it ok , please pull request. 

Thank you.
