### PR TITLE
Added prefix option

### DIFF
--- a/jquery.simple-color-picker.js
+++ b/jquery.simple-color-picker.js
@@ -12,7 +12,8 @@ $.fn.simpleColorPicker = function(options) {
 				, '#660000', '#783f04', '#7f6000', '#274e13', '#0c343d', '#073763', '#20124d', '#4C1130'],
         showEffect: '',
         hideEffect: '',
-        onChangeColor: false
+        onChangeColor: false,
+        prefix: false
     };
 
     var opts = $.extend(defaults, options);
@@ -22,7 +23,7 @@ $.fn.simpleColorPicker = function(options) {
 
         var colorsMarkup = '';
 
-        var prefix = txt.attr('id').replace(/-/g, '') + '_';
+        var prefix = setPrefix(txt);
 
         for(var i = 0; i < opts.colors.length; i++){
             var item = opts.colors[i];
@@ -98,6 +99,18 @@ $.fn.simpleColorPicker = function(options) {
                 box.slideDown();
             else
                 box.show();
+        }
+
+        function setPrefix(context) {
+          if (typeof opts.prefix === 'function') {
+            return opts.prefix.call(context) + "_";
+          }
+
+          if (typeof opts.prefix === 'string') {
+            return opts.prefix + '_';
+          }
+
+          return context.attr('id').replace(/-/g, '') + '_';
         }
     });
 };


### PR DESCRIPTION
Prefix change by function, string.
# Example
## function

HTML

``` html
<div class="parent_container">
    <a class="color">color picker</a>
    <div id="result"></div>
</div>
```

JS

``` javascript
$(document).ready(function() {
    $('.color').simpleColorPicker({prefix: function(){
        return this.parent('div').attr('class');
    }});
});
```
#### Result

``` html
<div class="color-picker" id="parent_container_color-picker" style="position: absolute; left: 8px; top: 199.567px; display: block;" >
<!-- color picker -->
</div>
```
## string

``` html
<div class="parent_container">
    <a class="color">color picker</a>
    <div id="result"></div>
</div>
```

``` javascript
$(document).ready(function() {
    $('.color').simpleColorPicker({prefix: "PREFIXXXXXXX"});
});
```
#### Result

``` html
<div id="PREFIXXXXXXX_color-picker" style="position: absolute; left: 8px; top: 199.567px; display: block;" class="color-picker">
<!-- color picker -->
</div>
```
